### PR TITLE
2024_05_25 revisions

### DIFF
--- a/actions.json
+++ b/actions.json
@@ -45,7 +45,7 @@
     },
     {
       "Name": "Landslide",
-      "Description": "Pick up any 2 Loot Tokens and move each of them to a different spaces."
+      "Description": "Pick up 1 Loot Token and move it to a different explored space."
     },
     {
       "Name": "Pilfer",
@@ -62,22 +62,6 @@
     {
       "Name": "Purge",
       "Description": "Move each Acolyte on your Colossus's space to any adjacent space (you can move Acolytes to different spaces)."
-    },
-    {
-      "Name": "Reinforce",
-      "Description": "Reinforce one of your Banners in play. Flip it to show its reinforced side. This Banner cannot be replaced by an opponent."
-    },
-    {
-      "Name": "Reinforce",
-      "Description": "Reinforce one of your Banners in play. Flip it to show its reinforced side. This Banner cannot be replaced by an opponent."
-    },
-    {
-      "Name": "Reinforce",
-      "Description": "Reinforce one of your Banners in play. Flip it to show its reinforced side. This Banner cannot be replaced by an opponent."
-    },
-    {
-      "Name": "Reinforce",
-      "Description": "Reinforce one of your Banners in play. Flip it to show its reinforced side. This Banner cannot be replaced by an opponent."
     },
     {
       "Name": "Replace",

--- a/beast.json
+++ b/beast.json
@@ -42,5 +42,21 @@
     {
       "Name": "Rampage",
       "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
+    },
+    {
+      "Name": "Rampage",
+      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
+    },
+    {
+      "Name": "Rampage",
+      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
+    },
+    {
+      "Name": "Rampage",
+      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
+    },
+    {
+      "Name": "Rampage",
+      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
     }
    ]

--- a/environments.json
+++ b/environments.json
@@ -13,7 +13,7 @@
     },
     {
       "Name": "Lair: Blood Beast",
-      "Description": "When resting, kill every Acolyte on or adjacent to the Beast's space.",
+      "Description": "When resting, kill every Acolyte on or adjacent to the Blood Beast's space.",
       "Beast Description": "Any Acolytes that share a space with the Beast die."
     },
     {
@@ -23,18 +23,18 @@
     },
     {
       "Name": "Lair: Hungry Beast",
-      "Description": "When resting, move each Loot Token from the Beast's space to adjacent spaces you choose.",
+      "Description": "When resting, move each Loot Token from the Hungry Beast's space to adjacent spaces you choose.",
       "Beast Description": "Every time the Beast leaves a space containing Loot Token(s), it takes the Loot Token(s) with it."
     },
     {
-      "Name": "Lair: Reinforcement Beast",
-      "Description": "When resting, Reinforce up to 2 Banners you have in play, and leave them in place after scoring them.",
-      "Beast Description": "When in a space with a Banner, reinforce it."
+      "Name": "Lair: Sturdy Beast",
+      "Description": "When resting, leave up to 2 of your Banners in play after scoring them.",
+      "Beast Description": "Banners on or adjacent to the Sturdy Beast cannot be replaced by opposing players."
     },
     {
       "Name": "Lair: Wealthy Beast",
-      "Description": "When resting, place 2 Gold from the bank in each space adjacent to the Beast.",
-      "Beast Description": "When leaving a space, leave 1 Gold from the bank there."
+      "Description": "When resting, place 2 Gold from the bank in each space adjacent to the Wealthy Beast.",
+      "Beast Description": "When on a space with a Banner, score it immediately as if its owner was Resting."
     },
     {
       "Name": "Launchpad",
@@ -47,7 +47,7 @@
     },
     {
       "Name": "Market",
-      "Description": "Discard cards from your hand. Collect 2 gold for each you discarded.",
+      "Description": "Discard cards from your hand. Collect 1 gold for each you discarded.",
       "Clarifications": "You can discard cards you just drew during this Rest. But your hand limit applies immediately. So if you had previously drawn up beyond your hand limit, you must discard down before scoring this Environment."
     },
     {

--- a/rules.md
+++ b/rules.md
@@ -31,10 +31,9 @@ Banners indicate which player will collect rewards for a given space.
 - Even if you move your Acolytes and Colossus off of that space, and another player Controls it, your Banner remains until they replace it or you Rest.
 - If you have no Banners in your hand, you cannot play anymore Banners. You cannot move Banners already in play.
 - When you Rest, you will collect rewards for each of your Banners, and return them to your hand. You can reuse Banners after they return to your hand. Sometimes there will be Gold on spaces (not just Loot Tokens); in these cases, keep the Gold on the space you're scoring.
-- Some cards and Environments will allow you to Reinforce a Banner. Flip your Banner to show the Reinforcement side. A Reinforced Banner cannot be replaced by an opponent.
 
 ## Environments
-Environments are special tiles with potentially big rewards. Raise one of your Banners on a Environment to claim its rewards when you Rest.
+Environments are special tiles with potentially big rewards. Raise one of your Banners on a Environment to claim its rewards when you Rest. 17 of these tiles are just Grass, which have no special effects.
 
 ## Loot Tokens
 Loot gives you smaller rewards. Loot tokens remain in play, and can be used on every turn. There are Loot tokens that give you Colossus Cards and Gold when you Rest. Raise one of your Banners on a space with a Loot Token to claim its rewards when you Rest.
@@ -49,10 +48,10 @@ Colossus Cards allow you to get Gold, move Acolytes around, and gain advantages 
 
 # Setup
 
-- Each player chooses a color, and receives a set of 1 Colossus, 5 Banners, and 10 Acolytes of that color 
-- You will begin the game with only 2 Acolytes in your hand. Set the other Acolytes aside.
+- Each player chooses a color, and receives a set of 1 Colossus, 6 Banners, and 10 Acolytes of that color 
 - Shuffle the Colossus Card deck and place it near the board. Deal each player 3 Colossus Cards.
-- Stack all Environment tiles face-down and shuffle them.
+- Place 1 Grass tile on any space on the board, along with 1 random Loot Token. Place every Colossus there.
+- Set aside 16 Grass Tiles face-down. Shuffle the Lair tiles and put 2 face-down with the Grass tiles. Shuffle the rest of the Environment Tiles, draw 8 and put them face-down with the 18 other tiles. Shuffle these 26 Tiles and keep them face-down. Return all other Environments and Lairs back to the box.
 - Shuffle all Loot Tokens and place them face-down.
 - Place all Colossi in the center space, and place a random Loot Token there.
 - Determine a first player. 
@@ -63,16 +62,16 @@ Colossi's gameplay simply consists of player turns. Continue taking turns until 
 
 ## Colossus Turn
 
-At the start of each turn, add 1 Acolyte from your supply to your hand (if there are any left in your supply). On your turn, do one of two things: 
+### Action Phase
+On your turn, draw 1 Colossus Card. Then, in any order, you can move up to 4 times, and play as many Colossus Cards as you want.
 
-1. **Take Actions**: 
-- First, draw 1 Colossus Card.
-- In any order, you may move your Colossus and Acolytes up to 4 times and play any number of Colossus Cards from your hand.
-- At the end of your turn, you may place Banners from your hand on any spaces you Control. If you place a Banner on a space containing an opposing Banner, return it to its owner's hand.
+### Banner Phase
+
+Then, you will do one (but not both) of the following:
+
+1. **Place Banners**: You may place Banners from your hand on any spaces you Control. If you place a Banner on a space containing an opposing Banner, return it to its owner's hand.
 
 2. **Rest**: Collect rewards from each space with one of your Banners. Resolve these in any order you choose. Return each Banner to your hand after you resolve it. If there is Gold on the space you're scoring, keep that Gold.
-
-You can only do one of the above, not both. If you take Actions, you will not collect rewards. If you rest, you will not take actions or place any Banners.
 
 ## Game End
 
@@ -80,7 +79,7 @@ Beast Master ends after each player has taken 15 turns.
 
 # Movement
 You have 4 Movements on your turn, and it costs 1 Movement to move your Colossus or an Acolyte 1 space in any direction. Colossi and Acolytes follow the same rules for movement.
-- **Exploring**: When moving into a space that has no Loot Token or Environment, you will discover what is there. Roll the die. If you roll 1-4, place a random Loot Token there. If you roll 5-6, place an Environment there. 
+- **Exploring**: When moving into a space that has no Loot Token or Environment, you will discover what is there. Draw an Environment tile from the deck you built during Setup. If it is Grass, put a Loot Token there. If it is a Beast Lair, immediately put the corrosponding Beast on that space.
 - **Road Movement**: When moving into a space that already contains your Colossus or one of your Acolytes, you may continue onward to any adjacent space for free. If you have your Colossus or Acolytes in multiple adjacent spaces, move long distances using just 1 Movement.
 - **Spawn an Acolyte**: For the cost of 1 Movement, place an Acolyte from your hand onto your Colossus’s space. You may immediately move that Acolyte to an adjacent space for free using Road Movement.
 


### PR DESCRIPTION
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-79403194-7fff-3a5d-7de4-b19d15e72c48"><div dir="ltr" style="margin-left:0pt;" align="center">
Problem | Notes | Solution
-- | -- | --
The Acolyte reserves idea is not good | Confusing. Also, majorly restricts movement at the beginning. | Go back to “you just have 10 acolytes. done”
It is not clear which spaces have an have not been explored | You move a loot token off the map. We don’t want to re-explore that space. | Create 15 Grass tiles. When you draw grass, you just put loot there.
Landslide is OP |   | It should only move 1 token, not 2
We are rarely resting / scoring | There is just too much incentive to not rest, and as a result we never do | Update turns so that you always take a normal turn (draw, move, play cards) but then you have a choice for your Banner phase:Place banners on any space you controlScore your banners
Wealthy Beast perk is lame | It’s not clear how you use it | Instead, its passive should be that it automatically scores the Banner in its space.
Lair descriptions should specify which beast they’re talking about |   |  
Beast Rest is boring and bad | We specifically want to move beasts around. Moving them back to their point of origin isn’t fun. | Remove this card
Beasts aren’t moving enough |   | Introduce many more Rampage cards
Market is OP |   | Reduce to 1 Gold, not 2
The concept of reinforcement is not great |   | Remove Reinforce cards from deck. Remove references to flipped over banners from rulesReinforcement Beast is:Passive: Banners on or adjacent to this Beast cannot be replaced by opponents.Lair: when resting, leave two Banners out there.

</div></b>