### PR TITLE
09_12_2024 changes

### DIFF
--- a/actions.json
+++ b/actions.json
@@ -1,8 +1,7 @@
 [
     {
       "Name": "Bolster",
-      "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
-      "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
+      "Description": "Place one Acolyte from your hand on each space where you already have an Acolyte."
     },
     {
       "Name": "Comandeer",
@@ -30,7 +29,8 @@
     },
     {
       "Name": "Evangelize",
-      "Description": "Place one Acolyte from your hand on each space where you already have an Acolyte."
+      "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
+      "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
     },
     {
       "Name": "Influence",

--- a/actions.json
+++ b/actions.json
@@ -25,7 +25,7 @@
     },
     {
       "Name": "Dominate",
-      "Description": "During the Banner phase of this turn, you may deploy Banners and score them as if you were resting. This card must be the first action you take this turn, and you cannot take any actions after playing this card."
+      "Description": "During the Banner phase of this turn, you may both deploy Banners and also score them as if you were resting. This card must be the first action you take this turn, and you cannot take any actions after playing this card."
     },
     {
       "Name": "Equalize",

--- a/actions.json
+++ b/actions.json
@@ -1,5 +1,10 @@
 [
     {
+      "Name": "Bolster",
+      "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
+      "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
+    },
+    {
       "Name": "Comandeer",
       "Description": "Replace an opposing Banner with one of your own."
     },
@@ -20,9 +25,12 @@
       "Description": "Replace each opposing Acolytes on your Colossus's space with Acolytes from your hand. Once you are out of Acolytes from your hand, stop."
     },
     {
-      "Name": "Equalize",
-      "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
-      "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
+      "Name": "Dominate",
+      "Description": "During the Banner phase of this turn, you may deploy Banners and score them as if you were resting. This card must be the first action you take this turn, and you cannot take any actions after playing this card."
+    },
+    {
+      "Name": "Evangelize",
+      "Description": "Place one Acolyte from your hand on each space where you already have an Acolyte."
     },
     {
       "Name": "Influence",
@@ -57,6 +65,10 @@
       "Description": "Move each Acolyte on your Colossus's space to any adjacent space (you can move Acolytes to different spaces)."
     },
     {
+      "Name": "Recall",
+      "Description": "Move any number of your Acolytes on the board to your Colossus's space."
+    },
+    {
       "Name": "Replace",
       "Description": "Swap any 2 Colossi on the island."
     },
@@ -67,6 +79,30 @@
     {
       "Name": "Sabotage",
       "Description": "Choose up to 3 spaces that have Banners but do not have Acolytes or Colossi on them. Remove the Banners there and return them to their owners’ hands."
+    },
+    {
+      "Name": "Secure",
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+    },
+    {
+      "Name": "Secure",
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+    },
+    {
+      "Name": "Secure",
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+    },
+    {
+      "Name": "Short Rest",
+      "Description": "Select one of your Banners on the board. Score it immediately, as if you were resting."
+    },
+    {
+      "Name": "Short Rest",
+      "Description": "Select one of your Banners on the board. Score it immediately, as if you were resting."
+    },
+    {
+      "Name": "Short Rest",
+      "Description": "Select one of your Banners on the board. Score it immediately, as if you were resting."
     },
     {
       "Name": "Steal",

--- a/actions.json
+++ b/actions.json
@@ -20,20 +20,9 @@
       "Description": "Replace each opposing Acolytes on your Colossus's space with Acolytes from your hand. Once you are out of Acolytes from your hand, stop."
     },
     {
-      "Name": "Dodge",
-      "Description": "(Play immediately after another player plays a card) If any of your Acolytes will die as a result of the card that was just played, you may move each of them to any adjacent space you choose."
-    },
-    {
-      "Name": "Dodge",
-      "Description": "(Play immediately after another player plays a card) If any of your Acolytes will die as a result of the card that was just played, you may move each of them to any adjacent space you choose."
-    },
-    {
       "Name": "Equalize",
-      "Description": "Any players with Acolytes on your Colossus's space put all of their Titan cards into a pile, shuffle them, and re-deal them amongst themselves beginning with you and continuing clockwise."
-    },
-    {
-      "Name": "Hegemony",
-      "Description": "Every Acolyte must move off of spaces you control. Their player chooses where they go."
+      "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
+      "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
     },
     {
       "Name": "Influence",
@@ -86,10 +75,6 @@
     {
       "Name": "Teleport",
       "Description": "Move any Colossus to any space."
-    },
-    {
-      "Name": "Terraform",
-      "Description": "Choose a Loot Token that is on a space that has no Environment tile. Then swap it with any Environment tile."
     },
     {
       "Name": "Vandalize",

--- a/actions.json
+++ b/actions.json
@@ -28,7 +28,7 @@
       "Description": "During the Banner phase of this turn, you may deploy Banners and score them as if you were resting. This card must be the first action you take this turn, and you cannot take any actions after playing this card."
     },
     {
-      "Name": "Evangelize",
+      "Name": "Equalize",
       "Description": "Put all of your Colossus cards into a pile along with any players who have Acolytes on your Colossus's space. Shuffle them, and re-deal them beginning with you.",
       "Clarifications": "Only deal cards back out to yourself, and to players who had Acolytes on your Colossus's space."
     },

--- a/actions.json
+++ b/actions.json
@@ -82,15 +82,15 @@
     },
     {
       "Name": "Secure",
-      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner from your hand."
     },
     {
       "Name": "Secure",
-      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner from your hand."
     },
     {
       "Name": "Secure",
-      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner."
+      "Description": "Choose a space where you have multiple Acolytes. Return them to your hand, and replace them with a Banner from your hand."
     },
     {
       "Name": "Short Rest",

--- a/beast.json
+++ b/beast.json
@@ -34,29 +34,5 @@
     {
       "Name": "Rampage",
       "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
-    },
-    {
-      "Name": "Rampage",
-      "Description": "Move a Beast twice (a Beast can only move to adjacent spaces)."
     }
    ]

--- a/divine_gifts.json
+++ b/divine_gifts.json
@@ -5,7 +5,7 @@
     },
     {
       "Name": "Audacity",
-      "Description": "Each Colossus collects 2 Gold for every space they control adjacent to one or more Beasts."
+      "Description": "Each Colossus collects 2 Gold for every space they control that is occupied by a Beast, or adjacent to one or more Beasts."
     },
     {
       "Name": "Authority",

--- a/divine_gifts.json
+++ b/divine_gifts.json
@@ -5,7 +5,7 @@
     },
     {
       "Name": "Audacity",
-      "Description": "Each Colossus collects 2 Gold for every space they control adjacent a Beast."
+      "Description": "Each Colossus collects 2 Gold for every space they control adjacent to one or more Beasts."
     },
     {
       "Name": "Authority",

--- a/environments.json
+++ b/environments.json
@@ -38,7 +38,8 @@
     {
       "Name": "Lair: Time Beast",
       "Description": "Immediately after you rest, you may take another turn.",
-      "Beast Description": "When entering a space that contains a Banner, score the Banner for its owner immediately."
+      "Beast Description": "When entering a space that contains a Banner, score the Banner for its owner immediately.",
+      "Clarifications": "The Time Beast only scores Banners in this manner when moving into a space. If you place a Banner on the space where the Time Beast already is, the Banner is not immediately scored."
     },
     {
       "Name": "Lair: Wind Beast",

--- a/environments.json
+++ b/environments.json
@@ -1,11 +1,15 @@
 [
     {
+      "Name": "Beast Mantle",
+      "Description": "When resting, move each Beast to any space you choose."
+    },
+    {
       "Name": "Deep Mines",
-      "Description": "When drawn, put 1 Gold from the Bank here. When resting, collect all Gold here, then, put 2 Gold from the Bank here. Every time this happens, double the amount from the Bank."
+      "Description": "When drawn, put 3 Gold from the Bank here. When resting, collect all Gold here, then add 4 Gold from the bank here. Each time this happens, increase the Gold by 1."
     },
     {
       "Name": "Golden Dunes",
-      "Description": "Any time an Acolyte or Colossus moves here, place 1 Gold from the bank here. When resting, collect all Gold here."
+      "Description": "Any time an Acolyte or Colossus moves here or passes through here using Road Movement, place 1 Gold from the bank here. When resting, collect all Gold here."
     },
     {
       "Name": "Hallowed Ground",
@@ -17,6 +21,11 @@
       "Beast Description": "Acolytes on this space immediately die."
     },
     {
+      "Name": "Lair: Golden Beast",
+      "Description": "When resting, place 1 Gold from the bank in each space adjacent to the Golden Beast.",
+      "Beast Description": "When leaving a space, leave 1 Gold from the Bank in the space it leaves."
+    },
+    {
       "Name": "Lair: Hungry Beast",
       "Description": "When resting, move each Loot Token from the Hungry Beast's space to adjacent spaces you choose.",
       "Beast Description": "When the Hungry Beast leaves a space, it takes the Loot Token(s) from that space with it."
@@ -24,12 +33,12 @@
     {
       "Name": "Lair: Stone Beast",
       "Description": "When resting, leave up to 2 of your Banners in play after scoring them.",
-      "Beast Description": "Banners on or adjacent to this space cannot be replaced."
+      "Beast Description": "Banners on this space cannot be replaced by opponents. Acolytes on this space cannot be killed or moved."
     },
     {
-      "Name": "Lair: Wealthy Beast",
-      "Description": "When resting, place 2 Gold from the bank in each space adjacent to the Wealthy Beast.",
-      "Beast Description": "When a Banner is this space, score it immediately as if its owner was Resting."
+      "Name": "Lair: Time Beast",
+      "Description": "When resting: if you have Banners on or adjacent to the Time Beast's space, score them twice.",
+      "Beast Description": "When entering a space that contains a Banner, score the Banner for its owner immediately."
     },
     {
       "Name": "Lair: Wind Beast",
@@ -38,8 +47,7 @@
     },
     {
       "Name": "Launchpad",
-      "Description": "When resting, move each Acolyte, Colossus, Beast, Loot Token, and Gold token here to any space.",
-      "Clarifications": "Keep in mind that you only place Banners down at the end of regular turns. So if you move an Acolyte to a space and take control of it, you still cannot score it during this Rest."
+      "Description": "When resting: After collecting your Banner here, pick up every game component on or adjacent to this space. Move each of them to any explored space you choose."
     },
     {
       "Name": "Magnetic Maar",
@@ -52,7 +60,7 @@
     },
     {
       "Name": "Moat",
-      "Description": "When resting, collect 2 Gold for each adjacent space you control. Steal 2 Gold from each player who controls an adjacent space."
+      "Description": "When resting, collect 1 Gold for each adjacent space you control. Steal 1 Gold from each player who controls an adjacent space."
     },
     {
       "Name": "Mountaintop of the Giants",
@@ -68,12 +76,12 @@
     },
     {
       "Name": "Speedy Slopes",
-      "Description": "When resting, you may move each of your Acolytes once.",
+      "Description": "When resting, place all Acolytes from here hand here. Then you may move each of your Acolytes once.",
       "Clarifications": "Keep in mind that you only place Banners down at the end of regular turns. So if you move an Acolyte to a space and take control of it, you still cannot score it during this Rest."
     },
     {
       "Name": "Teleporter",
-      "Description": "When resting, swap everything here with everything from another explored space. Then score that other space."
+      "Description": "When resting, swap all game components here with all game components from another explored space. Then score that other space."
     },
     {
       "Name": "Time Turner",
@@ -84,13 +92,9 @@
       "Description": "When placing a Banner here, put 2 Gold from the bank here. When resting, collect all Gold here."
     },
     {
-      "Name": "Mantle",
-      "Description": "When resting, turn over cards from the Colossus deck until you draw a Beast card. Play it immediately and discard all other drawn cards."
-    },
-    {
       "Name": "The Void",
-      "Description": "When resting, replace an Environment with a new random one. If your Banner is there, score it.",
-      "Clarifications": "You should always remove a Banner after scoring it. So if you had already scored the Environment you replaced, you would not score the new one."
+      "Description": "When resting: replace any Environment with a new random one. If your Banner is there, score it.",
+      "Clarifications": "Since you prepard a deck of Environments at the start of the game, you might need to go to the box to get a new Environment tile."
     },
     {
       "Name": "Volcano",

--- a/environments.json
+++ b/environments.json
@@ -37,7 +37,7 @@
     },
     {
       "Name": "Lair: Time Beast",
-      "Description": "When resting: if you have Banners on or adjacent to the Time Beast's space, score them twice.",
+      "Description": "Immediately after you rest, you may take another turn.",
       "Beast Description": "When entering a space that contains a Banner, score the Banner for its owner immediately."
     },
     {
@@ -82,10 +82,6 @@
     {
       "Name": "Teleporter",
       "Description": "When resting, swap all game components here with all game components from another explored space. Then score that other space."
-    },
-    {
-      "Name": "Time Turner",
-      "Description": "Immediately after you rest, you may take a normal turn."
     },
     {
       "Name": "Treasure Trove",

--- a/environments.json
+++ b/environments.json
@@ -76,7 +76,7 @@
     },
     {
       "Name": "Speedy Slopes",
-      "Description": "When resting, place all Acolytes from here hand here. Then you may move each of your Acolytes once.",
+      "Description": "When resting, place all Acolytes from you hand here. Then you may move each of your Acolytes once.",
       "Clarifications": "Keep in mind that you only place Banners down at the end of regular turns. So if you move an Acolyte to a space and take control of it, you still cannot score it during this Rest."
     },
     {

--- a/equipment.json
+++ b/equipment.json
@@ -17,7 +17,7 @@
     },
     {
       "Name": "Shield",
-      "Description": "Acolytes on your Colossus's space cannot be killed or moved. Banners on your Colossus's space cannot be replaced."
+      "Description": "Acolytes on your Colossus's space cannot be killed or moved. If your Colossus is on the same space as one of your Banners, that Banner cannot be replaced by an opponent."
     },
     {
       "Name": "Supply Chest",

--- a/equipment.json
+++ b/equipment.json
@@ -5,7 +5,7 @@
     },
     {
       "Name": "Blinding Speed",
-      "Description": "On your turn, you may move 5 times instead of 4."
+      "Description": "On your turn, you have 5 Actions instead of 4."
     },
     {
       "Name": "Outpost",

--- a/equipment.json
+++ b/equipment.json
@@ -17,7 +17,7 @@
     },
     {
       "Name": "Shield",
-      "Description": "Acolytes on your Colossus's space cannot be killed."
+      "Description": "Acolytes on your Colossus's space cannot be killed or moved. Banners on your Colossus's space cannot be replaced."
     },
     {
       "Name": "Supply Chest",

--- a/equipment.json
+++ b/equipment.json
@@ -8,12 +8,12 @@
       "Description": "On your turn, you may move 5 times instead of 4."
     },
     {
-      "Name": "Blood Lust",
-      "Description": "When you kill an opposing Acolyte, collect 2 Gold instead of 1."
-    },
-    {
       "Name": "Outpost",
       "Description": "When placing Banners, you may place two Banners on the same space."
+    },
+    {
+      "Name": "Prod",
+      "Description": "When your Colossus moves into a space containing Beasts or other Colossi, you may move them 1 space in any direction."
     },
     {
       "Name": "Shield",

--- a/rules.md
+++ b/rules.md
@@ -51,9 +51,9 @@ Colossus Cards allow you to get Gold, move Acolytes around, and gain advantages 
 
 # Setup
 
-- Each player chooses a color, and receives a set of 1 Colossus, 6 Banners, and 10 Acolytes of that color 
+- Each player chooses a color, and receives a set of 1 Starting Environment tile, 1 Colossus, 6 Banners, and 10 Acolytes of that color 
 - Shuffle the Colossus Card deck and place it near the board. Deal each player 3 Colossus Cards.
-- Place 1 Grass tile on any space on the board, along with 1 random Loot Token. Place every Colossus there.
+- Beginning with the first player, take turns placing your Starting Environment tiles on any unoccupied space you choose. Place your Colossus on your Starting Environment Tile, and place a Loot Token of 1 Gold on this space.
 - Set aside 16 Grass Tiles face-down. Shuffle the Lair tiles and put 2 face-down with the Grass tiles. Shuffle the rest of the Environment Tiles, draw 8 and put them face-down with the 18 other tiles. Shuffle these 26 Tiles and keep them face-down. Return all other Environments and Lairs back to the box.
 - Shuffle all Loot Tokens and place them face-down.
 - Place all Colossi in the center space, and place a random Loot Token there.
@@ -66,15 +66,17 @@ Colossi's gameplay simply consists of player turns. Continue taking turns until 
 ## Colossus Turn
 
 ### Action Phase
-On your turn, draw 1 Colossus Card. Then, in any order, you can move up to 4 times, and play as many Colossus Cards as you want.
+1. Draw 1 Colossus Card.
+2. Take 4 Actions. With your Action, you may either play a Colossus card, or move (see full Movement rules in the next section).
+3. You may move each Beast 1 space.
 
 ### Banner Phase
 
 Then, you will do one (but not both) of the following:
 
-1. **Place Banners**: You may place Banners from your hand on any spaces you Control. If you place a Banner on a space containing an opposing Banner, return it to its owner's hand.
+1. **Deploy**: You may place Banners from your hand on any spaces you Control. If you place a Banner on a space containing an opposing Banner, return it to its owner's hand. You may also move your deployed Banners to other spaces you control.
 
-2. **Rest**: Collect rewards from each space with one of your Banners. Resolve these in any order you choose. Return each Banner to your hand after you resolve it. If there is Gold on the space you're scoring, keep that Gold.
+2. **Rest**: Collect each of your deployed Banners, in any order you choose. Each time you collect a Banner, collect the reward for that space or activate its Environment effect. If there is Gold on the space you're scoring, keep that Gold.
 
 ## Game End
 
@@ -85,7 +87,7 @@ There are 3 ways to win the game. If you achieve any of the following, the game 
 - **Crusader**: You kill 20 opposing Acolytes.
 
 # Movement
-You have 4 Movements on your turn, and it costs 1 Movement to move your Colossus or an Acolyte 1 space in any direction. Colossi and Acolytes follow the same rules for movement.
+You have 4 Actions on your turn, and it costs 1 Action to move your Colossus or an Acolyte 1 space in any direction. Colossi and Acolytes follow the same rules for movement.
 - **Exploring**: When moving into a space that has no Loot Token or Environment, you will discover what is there. Draw an Environment tile from the deck you built during Setup. If it is Grass, put a Loot Token there. If it is a Beast Lair, immediately put the corrosponding Beast on that space.
 - **Road Movement**: When moving into a space that already contains your Colossus or one of your Acolytes, you may continue onward to any adjacent space for free. If you have your Colossus or Acolytes in multiple adjacent spaces, move long distances using just 1 Movement.
 - **Spawn an Acolyte**: For the cost of 1 Movement, place an Acolyte from your hand onto your Colossus’s space. You may immediately move that Acolyte to an adjacent space for free using Road Movement.


### PR DESCRIPTION
<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-40a9ac13-7fff-c9d8-0733-061a9346e38b"><div dir="ltr" style="margin-left:0pt;" align="center">
Problem | Notes | Solution
-- | -- | --
Turns were long. Analysis paralysis prevailed. |   | Fixed number of actions per turn. Low. Maybe like 5You can:Move / spawnPlay a cardMove a beast
We wanted beasts to be constantly moving |   | See above. You can move it as an actionWe could reduce the number of beast cards too
Lairs aren’t visually distinct from other tiles |   | TBDCould use icons that match the beast their onCould have a special border or something
The “when resting” language is not that clear | Is the end of your turn “the banner phase”? And resting is an option in the banner phase? Feels muddy and not great. Whatever we decide, make all the tiles consistent | TBDRevisit when we talk about nouns and verbs in person
First player has huge advantage, and we had a big traffic jam out the gates |   | Each player decides where to start, and starts with a grass tile and a 1 gold lootYou could even add art that shows like “this is yellow base. You get 1 gold and 1 cards here.” make it distinct. That’s their starting tile.
Teleporter: the language of “everything” is too vague |   | Make it clear it includes banners, beasts, gold, tokens, acolytes, and colossi
Banners are too big |   | TBDCould just be a smaller component with the same icon? Revisit in design session
Gold coins and gold loot are too visually similar | Gets very confusing to look at the board and understand what your reward is | TBDRevisit in design session
Golden Dunes: Unclear if you add gold there when just passing through. |   | Clarify: when a player moves there, or passes through using road movement.
Wealthy beast scoring banners feels both OP and confusing | Scoring banners immediately on its space is crazy powerful and sort of confusing and anticlimactic | There are actually two concepts here.The gold beast:Lair effect: spray 1 gold adjacentBeast effect: leave a trail of goldBanner beast:Score banners when entering spaceLair: for YOUR banners on or adjacent to the beast, double score them
Wealthy Beast lair feels weird | Why would I ever want to do it? It feels impossibly complex to set up a play where it will benefit me | See above
Moat is stupidly OP |   | Reduce reward to 1 token instead of 2
Deep Mines never felt worth scoring | It can get very powerful. But it starts as kind of weakALSO, it gets very confusing if other gold is dropped there | TBDStart it at 2 or 3 gold instead of 1?Really rethink the whole idea. This concept is fun, but maybe the amount of gold there is pegged to something else, so it’s easy to remember how much you put there.could you alternatively just do a thing where you wager gold there? When placing banner, wager gold there – double it when you score
Hegemony is a bad card. It’s basically a worse version of purge |   | Remove it
Speedy Slopes feels pointless? | What if instead, you had something more like “place all the acolytes in your hand on spaces adjacent to this.” | This feels odd. Maybe kill it and return later? TBD
Similarly, why would I ever want to use launchpad? |   | TBDA much more useful version is something along the lines of “Take every acolyte in your hand, and put each of them on any space you choose.”It’s just not juicy enough. You could put loot tokens here. Or you could
Mantle also feels weak |   | Change it to “Move a beast to any space you choose” and rename to Beast MantleThis sets up big plays where you could do this right before activating a lairThis is just a card?
Terraform is confusing | It uses old language of “environmental tile”. It’s also just such a big insane move, it doesn’t feel like a card. It’s more like a tile. | Remove it
For the Void, it’s not totally clear what pile you’re drawing from | The setup of the game has you build a deck of tiles. Void means you’ll have 1 more tile than usual. Does that come from the box? Not a huge deal. Language just needs to be clear | TBD
Audacity is unclear if spaces are double counted | Right now it kind of sounds like a space you control adjacent to multiple beasts would be counted twice. It shouldn’t be | Adjust language to be more like “for each space you control that is adjacent to 1 or more beasts.”
The break point for winning with gold should be much lower | With the new scoring rules, people are just scoring less. Also the main way they scored was by killing. And that’s going away | Reduce the victory point to 30Keep an eye out for this – we might need to do everything per player.
Equalize: not clear whether you are included |   | Make the wording clear that it involves everyone on that space, including you.
Shield is not clear | The language feels like a legacy from when we only had blood beast. | TBDMaybe change to “cannot be killed or moved”?
Stone Beast seems underwhelming |   | TBDWhat if it was like “For the stone beast’s space and all adjacent spaces: your banners cannot be replaced by opponents, and your acolytes cannot be killed or moved by opponents.”This effect might be too big, and too gnarly to track. What if it’s just the beast’s space?
The wording on Dodge is outdated | It only accounts for “if your acolyte would die because of a card that was played.” But tiles / beasts could kill acolytes too. | TBDConsider whether we really want this? It’s so different from the rest of the game. If we keep it, update the textLet’s cut it for now

</div></b>