### PR TITLE
Remove Loot Cubes

### DIFF
--- a/action.json
+++ b/action.json
@@ -40,10 +40,6 @@
       "Description": "Push all Acolytes adjacent to your Colossus 1 space away. Acolytes pushed off the island are killed."
     },
     {
-      "Name": "Magnetize",
-      "Description": "Pick up Loot cubes from 1 space, and move them to your Colossus's space."
-    },
-    {
       "Name": "Pilfer",
       "Description": "Draw 2 Colossus cards."
     },

--- a/divine_gift.json
+++ b/divine_gift.json
@@ -53,7 +53,7 @@
     },
     {
       "Name": "Windfall",
-      "Description": "Each Colossi collects the reward of their space as if they had a Banner there."
+      "Description": "Each Colossi collects the Loot reward of their space as if they had a Banner there (does not apply to special environments)."
     },
     {
       "Name": "Exchange",

--- a/divine_gift.json
+++ b/divine_gift.json
@@ -66,9 +66,5 @@
     {
       "Name": "Mimesis",
       "Description": "Beginning with the player to your left, then continuing clockwise, each player may steal 1 Trait from an opponent."
-    },
-    {
-      "Name": "Harvest",
-      "Description": "If any Colossus that is a space that produces Loot cubes, that space produces its Loot cubes again immediately."
     }
    ]

--- a/environment.json
+++ b/environment.json
@@ -5,11 +5,11 @@
     },
     {
       "Name": "Deep Mines",
-      "Description": "When drawn, put 3 Gold Loot cubes from the Bank here. After resting here, add 4 Gold from the bank here. Each time this happens, increase the Gold by 1."
+      "Description": "When drawn, put 3 Gold cubes from the Bank here. After resting here, add 5 Gold cubes from the bank here. Each time this happens, increase the Gold by 2."
     },
     {
       "Name": "Golden Dunes",
-      "Description": "Any time an Acolyte or Colossus moves here or passes through here using Road Movement, place 1 Gold Loot cube from the bank here."
+      "Description": "Any time an Acolyte or Colossus moves here or passes through here using Road Movement, place 1 Gold cube from the bank here."
     },
     {
       "Name": "Hallowed Ground",
@@ -22,18 +22,13 @@
     },
     {
       "Name": "Lair: Golden Beast",
-      "Description": "When resting, place 1 gold Loot cube from the bank in each space adjacent to the Golden Beast.",
-      "Beast Description": "When leaving a space, leave 1 gold Loot cube from the Bank in the space it leaves."
-    },
-    {
-      "Name": "Lair: Hungry Beast",
-      "Description": "When resting, move each Loot cube from the Hungry Beast's space to adjacent spaces you choose.",
-      "Beast Description": "When the Hungry Beast leaves a space, it takes the Loot cubes from that space with it."
+      "Description": "When resting, place 1 gold cube from the bank in each space adjacent to the Golden Beast.",
+      "Beast Description": "When leaving a space, leave 1 gold cube from the Bank in the space it leaves."
     },
     {
       "Name": "Lair: Bountiful Beast",
-      "Description": "When resting, the Bountiful Beast's space, and all adjacent spaces produce their Loot cubes again.",
-      "Beast Description": "When moving into a space that produces Loot cubes, that space produces its Loot cubes again immediately."
+      "Description": "When resting, choose up to 2 adjacent spaces that have Loot rewards (does not apply to special environments). Collect those rewards as if you controlled them.",
+      "Beast Description": "When scoring this space, triple its reward from Loot (this has no effect on special environments)."
     },
     {
       "Name": "Lair: Stone Beast",
@@ -54,10 +49,6 @@
     {
       "Name": "Launchpad",
       "Description": "When resting: After collecting your Banner here, pick up every game component on or adjacent to this space. Move each of them to any tile you choose."
-    },
-    {
-      "Name": "Magnetic Maar",
-      "Description": "When resting, choose an adjacent space, and move all Loot cubes from that space here. Then, score this space."
     },
     {
       "Name": "Market",
@@ -95,7 +86,7 @@
     },
     {
       "Name": "Treasure Trove",
-      "Description": "When deploying or replacing a Banner here, put 3 Gold Loot cubes from the bank here."
+      "Description": "When deploying or replacing a Banner here, put 3 Gold cubes from the bank here."
     },
     {
       "Name": "The Void",

--- a/rules.md
+++ b/rules.md
@@ -20,25 +20,30 @@ Acolytes move like Colossi, but die frequently.
 Beasts are monsters who haunt this island. Each has a passive effect and a special Lair Environment that causes a big action. In each game, you will play with 2 randomly selected Beasts.
 
 ## Gold
-If you collect 50 Gold, the game ends and you immediately win. Gain gold from cards and by scoring your Banners to claim the rewards from Environmnets and Loot cubes.
+If you collect 50 Gold, the game ends and you immediately win. Gain gold from cards and by scoring your Banners to claim the rewards from Environmnets and Loot.
 
 ## Banners
 Banners indicate which player will collect rewards for a given space.
 - You can raise your Banners at the end of your turn on spaces you Control. There can only be 1 Banner on a given space. If there was an opponent's Banner on the space where you raised one, return it to its owner's hand.
 - Even if you move your Acolytes and Colossus off of that space, and another player Controls it, your Banner remains until they replace it or you Rest.
 - If you have no Banners in your hand, you cannot play anymore Banners. You cannot move Banners already in play.
-- When you Rest, you will collect rewards for each of your Banners, and return them to your hand. Collect any Loot cubes on the space you're scoring, and activate any Environment effects. You can reuse Banners after they return to your hand. 
+- When you Rest, you will collect rewards for each of your Banners, and return them to your hand. Collect any Loot on the space you're scoring, and activate any Environment effects. You can reuse Banners after they return to your hand. 
 
 ## Environments
 Environments are special tiles with potentially big rewards. Raise 1 of your Banners on a Environment to claim its rewards when you Rest. 16 of these tiles are just Grass, which have no special effects.
 
-## Loot cubes
-Loot gives you smaller rewards. Score 1 of your Banners on a space with Loot cubes to claim their rewards. 
+## Loot 
+Loot gives you smaller rewards. Score 1 of your Banners on a space with Loot to claim their rewards. 
 
 Types of Loot: 
-- **Gold**: For each golden Loot cube, collect 1 Gold.
-- **Cards**: For each blue Loot cube, draw 1 Colossus Card.
-- **Traits**: For each green Loot cube, gain 1 Trait. Traits continually give your Colossus a boost. You can only have 2 Traits at a time. Choose 1 of the 3 face-up Traits, or the top Trait from the Trait deck. There should always be 3 face-up Traits. You can only have 2 Traits at a time, so if you gain a third, you must immediately discard 1 of them. Keep a separate discard pile for Traits.
+- **Gold**: For each golden Loot, collect 1 Gold.
+- **Cards**: For each blue Loot, draw 1 Colossus Card.
+- **Traits**: For each green Loot, gain 1 Trait. 
+
+Note: Loot is different from special environments. Some cards and Beasts will grant your rewards related to Loot. Those rewards do not apply to special environments.
+
+## Gold cubes
+Some Environments and Beasts will leave Gold cubes on the board. If you score a space with Gold cubes, you will collect them. Gain a Gold on the score tracker, and return the Gold cubes to the bank.
 
 ## Colossus Cards
 Colossus Cards allow you to get Gold, move Acolytes around, and gain advantages over opponents. You have a hand limit of 6 Cards, and must immediately discard down to 6 if you ever have more. There are 4 types of Colossus Card:
@@ -49,7 +54,7 @@ Colossus Cards allow you to get Gold, move Acolytes around, and gain advantages 
 - **Divine Gift**: Reward Colossi based on their position. These gifts go to all Colossi, so good timing is crucial.
 
 ## Traits
-Traits are cards that give your Colossus a boost. You can only have 2 Traits in play at a time. At any given time there will be 3 face-up Traits and a Trait deck. When you select a Trait, you may draw from the deck, or choose 1 of the face-up Traits. If you choose a face-up Trait, replace it with another face-up Trait from the deck before the next player chooses. 
+Traits are cards that give your Colossus a boost. You can only have 2 Traits in play at a time. You may discard one of your Traits at any time. At any given time there will be 3 face-up Traits and a Trait deck. When you select a Trait, you may draw from the deck, or choose 1 of the face-up Traits. If you choose a face-up Trait, replace it with another face-up Trait from the deck before the next player chooses. Traits continually give your Colossus a boost. 
 
 Designer note: For your first game, do not play with Traits. They make the game much more interesting, but it's best to learn the basics without them.
 
@@ -58,7 +63,7 @@ Designer note: For your first game, do not play with Traits. They make the game 
 - Each player chooses a color, and receives a set of 1 Starting Environment tile, 1 Colossus, 6 Banners, and 10 Acolytes of that color. 
 - Shuffle the Trait deck, and lay out 3 face-up. Take turns selecting either a face-up Trait, or the top card of the Trait deck. If you take a face-up Trait, replace it with another face-up Trait from the deck before the next player chooses. Once each player has a Trait, leave 3 face-up Traits beside the Trait deck.
 - Shuffle the Colossus Card deck and place it near the board. Deal each player 3 Colossus Cards.
-- Beginning with the first player, take turns placing your Starting Environment tiles on any unoccupied space you choose. Place your Colossus on your Starting Environment Tile, and place the corresponding Loot cubes on that space.
+- Beginning with the first player, take turns placing your Starting Environment tiles on any unoccupied space you choose. Place your Colossus on your Starting Environment Tile.
 - Set aside 16 Grass Tiles face-down. Shuffle the Lair tiles and put 2 face-down with the Grass tiles. Shuffle the rest of the Environment Tiles, draw 8 and put them face-down with the 18 other tiles. Shuffle these 26 Tiles and keep them face-down. Return all other Environments and Lairs back to the box.
 - Determine a first player. 
 
@@ -69,10 +74,9 @@ Colossi's gameplay simply consists of player turns. Continue taking turns until 
 ## Colossus Turn
 
 ### Action Phase
-1. **Replenish**: For any tile that produces Loot cubes, but currently has no Loot cubes on it, place corresponding Loot cubes on it. 
-2. **Draw**: Draw 1 Colossus Card.
-3. **Actions**: Take 4 Actions. With your Action, you may either play a Colossus card, or move (see full Movement rules in the next section).
-4. **Move Beast**: You may move a Beast 1 space.
+1. **Draw**: Draw 1 Colossus Card.
+2. **Actions**: Take 4 Actions. With your Action, you may either play a Colossus card, or move (see full Movement rules in the next section).
+3. **Move Beast**: You may move a Beast 1 space.
 
 ### Banner Phase
 

--- a/trait.json
+++ b/trait.json
@@ -106,9 +106,5 @@
     {
       "Name": "Miserly",
       "Description": "Every time you gain Gold, gain 1 additional Gold. However, you can only have 3 Acolytes and 2 Banners in play at a time."
-    },
-    {
-      "Name": "Resourceful",
-      "Description": "When scoring Loot cubes, you may ignore their color, and choose whether the cube is Gold, Card, or Trait."
     }
 ]

--- a/trait.json
+++ b/trait.json
@@ -28,10 +28,6 @@
       "Description": "You can only have 1 Banner in play at a time. However, you may score that Banner immediately upon deploying it at the end of your turn."
     },
     {
-      "Name": "Resolute",
-      "Description": "When placing Banners, you may place 2 Banners on the same space. When resting, double your reward from Loot on that space."
-    },
-    {
       "Name": "Domineering",
       "Description": "When your Colossus moves into a space containing Beasts or other Colossi, you may move them 1 space in any direction."
     },

--- a/trait.json
+++ b/trait.json
@@ -102,5 +102,9 @@
     {
       "Name": "Miserly",
       "Description": "Every time you gain Gold, gain 1 additional Gold. However, you can only have 3 Acolytes and 2 Banners in play at a time."
+    },
+    {
+      "Name": "Resourceful",
+      "Description": "When scoring Loot or Gold cubes from your Colossus's space, double the Loot and Gold rewards."
     }
 ]


### PR DESCRIPTION
Removed the whole concept of Loot Cubes from the game. They cluttered the board and added a lot of overhead. This did mean we had to remove a couple cool little ideas. But the tradeoff was well worth it. Massively simplified a tedious part of the game.